### PR TITLE
FIX typo at ConverterK2ETest test6 case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ local.properties
 .classpath
 .project
 logs/
+.idea
 work/Tomcat/
 
 # Spring

--- a/src/test/java/org/elasticsearch/plugin/utilTest/ConverterK2ETest.java
+++ b/src/test/java/org/elasticsearch/plugin/utilTest/ConverterK2ETest.java
@@ -77,7 +77,7 @@ public class ConverterK2ETest {
         String result = convert.convert(token);
         
         System.out.println(result);
-        assertEquals("samsung1", result);
+        assertEquals("tlsghsdugod()", result);
     }
 
 }


### PR DESCRIPTION
안녕하십니까. 엘라스틱서치 실무 가이드 책의 javacafe 코드를 공부하고 있는 한 개발자 입니다.
ConverterK2ETest 테스트 케이스 6번은 신혼여행 -> tlsghsdugod을 의미하는 테스트케이스 인듯 합니다.
그러나 assert문에서는 테스트 케이스 5번의 문자열인 samsung1과 비교하고 있습니다.
의도치 않은 오타로 보여서 PR 요청 드립니다.