### PR TITLE
FIX AbstrackKoreanParser char underflow logic

### DIFF
--- a/src/main/java/org/elasticsearch/index/common/parser/AbstractKoreanParser.java
+++ b/src/main/java/org/elasticsearch/index/common/parser/AbstractKoreanParser.java
@@ -30,7 +30,7 @@ public abstract class AbstractKoreanParser {
         for(char ch : arrCh) {
             
             // 처리 할 char의 유니코드 인덱스를 구한다.
-            char unicodeIndex = (char)(ch - JamoUtil.START_KOREA_UNICODE);
+            int unicodeIndex = ch - JamoUtil.START_KOREA_UNICODE;
 
             // 한글 유니코드 범위 : 0xAC00 ~ 0xD7AF (11184개)
             // 한글 유니코드인지 검사한다.            


### PR DESCRIPTION
안녕하십니까.
char 형의 최솟값은 0인듯 합니다.
`public static final char MIN_VALUE = '\u0000';`
그래서 그런지 unicodeIndex에서 받는 0의 인덱스는 무조건 0 보다 크거나 같게 되고 아래 수식의 왼쪽 부분은 무의미 한듯 합니다.
`if(unicodeIndex >= 0 && unicodeIndex <= 11184) {`
의미가 맞기 위해서는 char의 형변환이 삭제되어야 할듯 합니다. 